### PR TITLE
Revert android-tools to RPM version from Fedora repos

### DIFF
--- a/files/scripts/base/bazzite.sh
+++ b/files/scripts/base/bazzite.sh
@@ -21,26 +21,26 @@ dnf5 install -y \
     https://github.com/$GITOWNER/$GITREPO/releases/download/$KERNEL_TAG/kernel-devel-$KERNEL_VERSION.bazzite.fc$OS_VERSION.x86_64.rpm \
     https://github.com/$GITOWNER/$GITREPO/releases/download/$KERNEL_TAG/kernel-devel-matched-$KERNEL_VERSION.bazzite.fc$OS_VERSION.x86_64.rpm
 
-echo 'Downloading ublue-os akmods COPR repo file'
-curl -L https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/repo/fedora-$(rpm -E %fedora)/ublue-os-akmods-fedora-$(rpm -E %fedora).repo -o /etc/yum.repos.d/_copr_ublue-os-akmods.repo
+# echo 'Downloading ublue-os akmods COPR repo file'
+# curl -L https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/repo/fedora-$(rpm -E %fedora)/ublue-os-akmods-fedora-$(rpm -E %fedora).repo -o /etc/yum.repos.d/_copr_ublue-os-akmods.repo
 
-echo 'Installing zenergy kmod'
-dnf5 install -y \
-    akmod-zenergy-*.fc$OS_VERSION.x86_64
-    # akmod-zenpower3-*.fc$OS_VERSION.x86_64 \
-    # akmod-ryzen-smu-*.fc$OS_VERSION.x86_64 \
+# echo 'Installing zenergy kmod'
+# dnf5 install -y \
+#     akmod-zenergy-*.fc$OS_VERSION.x86_64
+#     # akmod-zenpower3-*.fc$OS_VERSION.x86_64 \
+#     # akmod-ryzen-smu-*.fc$OS_VERSION.x86_64 \
 
-akmods --force --kernels $KERNEL_VERSION.bazzite.fc$OS_VERSION.x86_64 --kmod zenergy
-modinfo /usr/lib/modules/$KERNEL_VERSION.bazzite.fc$OS_VERSION.x86_64/extra/zenergy/zenergy.ko.xz > /dev/null \
-    || (find /var/cache/akmods/zenergy/ -name \*.log -print -exec cat {} \; && exit 1)
+# akmods --force --kernels $KERNEL_VERSION.bazzite.fc$OS_VERSION.x86_64 --kmod zenergy
+# modinfo /usr/lib/modules/$KERNEL_VERSION.bazzite.fc$OS_VERSION.x86_64/extra/zenergy/zenergy.ko.xz > /dev/null \
+#     || (find /var/cache/akmods/zenergy/ -name \*.log -print -exec cat {} \; && exit 1)
 
-# akmods --force --kernels $KERNEL_VERSION.bazzite.fc$OS_VERSION.x86_64 --kmod zenpower3
-# modinfo /usr/lib/modules/$KERNEL_VERSION.bazzite.fc$OS_VERSION.x86_64/extra/zenpower3/zenpower3.ko.xz > /dev/null \
-#     || (find /var/cache/akmods/zenpower3/ -name \*.log -print -exec cat {} \; && exit 1)
+# # akmods --force --kernels $KERNEL_VERSION.bazzite.fc$OS_VERSION.x86_64 --kmod zenpower3
+# # modinfo /usr/lib/modules/$KERNEL_VERSION.bazzite.fc$OS_VERSION.x86_64/extra/zenpower3/zenpower3.ko.xz > /dev/null \
+# #     || (find /var/cache/akmods/zenpower3/ -name \*.log -print -exec cat {} \; && exit 1)
 
-# akmods --force --kernels $KERNEL_VERSION.bazzite.fc$OS_VERSION.x86_64 --kmod ryzen-smu
-# modinfo /usr/lib/modules/$KERNEL_VERSION.bazzite.fc$OS_VERSION.x86_64/extra/ryzen-smu/ryzen-smu.ko.xz > /dev/null \
-#     || (find /var/cache/akmods/ryzen-smu/ -name \*.log -print -exec cat {} \; && exit 1)
+# # akmods --force --kernels $KERNEL_VERSION.bazzite.fc$OS_VERSION.x86_64 --kmod ryzen-smu
+# # modinfo /usr/lib/modules/$KERNEL_VERSION.bazzite.fc$OS_VERSION.x86_64/extra/ryzen-smu/ryzen-smu.ko.xz > /dev/null \
+# #     || (find /var/cache/akmods/ryzen-smu/ -name \*.log -print -exec cat {} \; && exit 1)
 
-echo 'Removing ublue-os akmods COPR repo file'
-rm /etc/yum.repos.d/_copr_ublue-os-akmods.repo
+# echo 'Removing ublue-os akmods COPR repo file'
+# rm /etc/yum.repos.d/_copr_ublue-os-akmods.repo

--- a/files/scripts/base/bazzite.sh
+++ b/files/scripts/base/bazzite.sh
@@ -21,26 +21,26 @@ dnf5 install -y \
     https://github.com/$GITOWNER/$GITREPO/releases/download/$KERNEL_TAG/kernel-devel-$KERNEL_VERSION.bazzite.fc$OS_VERSION.x86_64.rpm \
     https://github.com/$GITOWNER/$GITREPO/releases/download/$KERNEL_TAG/kernel-devel-matched-$KERNEL_VERSION.bazzite.fc$OS_VERSION.x86_64.rpm
 
-# echo 'Downloading ublue-os akmods COPR repo file'
-# curl -L https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/repo/fedora-$(rpm -E %fedora)/ublue-os-akmods-fedora-$(rpm -E %fedora).repo -o /etc/yum.repos.d/_copr_ublue-os-akmods.repo
+echo 'Downloading ublue-os akmods COPR repo file'
+curl -L https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/repo/fedora-$(rpm -E %fedora)/ublue-os-akmods-fedora-$(rpm -E %fedora).repo -o /etc/yum.repos.d/_copr_ublue-os-akmods.repo
 
-# echo 'Installing zenergy kmod'
-# dnf5 install -y \
-#     akmod-zenergy-*.fc$OS_VERSION.x86_64
-#     # akmod-zenpower3-*.fc$OS_VERSION.x86_64 \
-#     # akmod-ryzen-smu-*.fc$OS_VERSION.x86_64 \
+echo 'Installing zenergy kmod'
+dnf5 install -y \
+    akmod-zenergy-*.fc$OS_VERSION.x86_64
+    # akmod-zenpower3-*.fc$OS_VERSION.x86_64 \
+    # akmod-ryzen-smu-*.fc$OS_VERSION.x86_64 \
 
-# akmods --force --kernels $KERNEL_VERSION.bazzite.fc$OS_VERSION.x86_64 --kmod zenergy
-# modinfo /usr/lib/modules/$KERNEL_VERSION.bazzite.fc$OS_VERSION.x86_64/extra/zenergy/zenergy.ko.xz > /dev/null \
-#     || (find /var/cache/akmods/zenergy/ -name \*.log -print -exec cat {} \; && exit 1)
+akmods --force --kernels $KERNEL_VERSION.bazzite.fc$OS_VERSION.x86_64 --kmod zenergy
+modinfo /usr/lib/modules/$KERNEL_VERSION.bazzite.fc$OS_VERSION.x86_64/extra/zenergy/zenergy.ko.xz > /dev/null \
+    || (find /var/cache/akmods/zenergy/ -name \*.log -print -exec cat {} \; && exit 1)
 
-# # akmods --force --kernels $KERNEL_VERSION.bazzite.fc$OS_VERSION.x86_64 --kmod zenpower3
-# # modinfo /usr/lib/modules/$KERNEL_VERSION.bazzite.fc$OS_VERSION.x86_64/extra/zenpower3/zenpower3.ko.xz > /dev/null \
-# #     || (find /var/cache/akmods/zenpower3/ -name \*.log -print -exec cat {} \; && exit 1)
+# akmods --force --kernels $KERNEL_VERSION.bazzite.fc$OS_VERSION.x86_64 --kmod zenpower3
+# modinfo /usr/lib/modules/$KERNEL_VERSION.bazzite.fc$OS_VERSION.x86_64/extra/zenpower3/zenpower3.ko.xz > /dev/null \
+#     || (find /var/cache/akmods/zenpower3/ -name \*.log -print -exec cat {} \; && exit 1)
 
-# # akmods --force --kernels $KERNEL_VERSION.bazzite.fc$OS_VERSION.x86_64 --kmod ryzen-smu
-# # modinfo /usr/lib/modules/$KERNEL_VERSION.bazzite.fc$OS_VERSION.x86_64/extra/ryzen-smu/ryzen-smu.ko.xz > /dev/null \
-# #     || (find /var/cache/akmods/ryzen-smu/ -name \*.log -print -exec cat {} \; && exit 1)
+# akmods --force --kernels $KERNEL_VERSION.bazzite.fc$OS_VERSION.x86_64 --kmod ryzen-smu
+# modinfo /usr/lib/modules/$KERNEL_VERSION.bazzite.fc$OS_VERSION.x86_64/extra/ryzen-smu/ryzen-smu.ko.xz > /dev/null \
+#     || (find /var/cache/akmods/ryzen-smu/ -name \*.log -print -exec cat {} \; && exit 1)
 
-# echo 'Removing ublue-os akmods COPR repo file'
-# rm /etc/yum.repos.d/_copr_ublue-os-akmods.repo
+echo 'Removing ublue-os akmods COPR repo file'
+rm /etc/yum.repos.d/_copr_ublue-os-akmods.repo

--- a/recipes/packages/foundation.yml
+++ b/recipes/packages/foundation.yml
@@ -85,6 +85,7 @@ modules:
         - pop-sound-theme
         - yaru-sound-theme
         # android stuff
+        - android-tools
         - python3-pyclip
         - waydroid
     remove:
@@ -121,6 +122,6 @@ modules:
         - rygel
         - yelp
 
-  - type: script
-    scripts:
-      - shared/android-tools.sh
+  # - type: script
+  #   scripts:
+  #     - shared/android-tools.sh


### PR DESCRIPTION
This fixes the issue of the newly implemented android-tools binary causing Waydroid to crash upon launch.