### PR TITLE
Waydroid-related additions

### DIFF
--- a/recipes/packages/foundation.yml
+++ b/recipes/packages/foundation.yml
@@ -10,6 +10,7 @@ modules:
         - dusansimic/themes
         - sneexy/zen-browser
         - trixieua/mutter-patched
+        - cuteneko/wayroid-helper
     optfix:
       - zen
     replace:
@@ -88,6 +89,7 @@ modules:
         - android-tools
         - python3-pyclip
         - waydroid
+        - waydroid-helper
     remove:
       packages:
         # fedora

--- a/recipes/packages/foundation.yml
+++ b/recipes/packages/foundation.yml
@@ -10,7 +10,7 @@ modules:
         - dusansimic/themes
         - sneexy/zen-browser
         - trixieua/mutter-patched
-        - cuteneko/wayroid-helper
+        - cuteneko/waydroid-helper
     optfix:
       - zen
     replace:

--- a/recipes/packages/foundation.yml
+++ b/recipes/packages/foundation.yml
@@ -87,6 +87,7 @@ modules:
         - yaru-sound-theme
         # android stuff
         - android-tools
+        - bindfs
         - python3-pyclip
         - waydroid
         - waydroid-helper


### PR DESCRIPTION
This PR adds `waydroid-helper`, a GUI for managing Waydroid addons, and `bindfs`, required for configuring shared folders between host and Waydroid.